### PR TITLE
Dependent Records

### DIFF
--- a/src/nucleus/equal.ml
+++ b/src/nucleus/equal.ml
@@ -199,19 +199,7 @@ and beta_reduce ~loc env ctx xus e u yvs t es =
 
 (** Reduction of [{xtes}.p] at type [{xts}] *)
 and projection_reduce ~loc env ctx xts p xtes =
-  let rec fold ctx xts xtes = match xts, xtes with
-    | [], [] -> Some ctx
-    | (x,ty)::xts, (x',ty',_)::xtes ->
-      if Name.eq_ident x x'
-      then equal_ty env ctx ty ty' >>= fun ctx ->
-        fold ctx xts xtes
-      else None
-    | _::_, [] | [], _::_ -> None
-    in
-  fold ctx xts xtes >>= fun ctx ->
-  let _,_,te = try List.find (fun (x,_,_) -> Name.eq_ident p x) xtes
-    with | Not_found -> Error.impossible ~loc "Equal.projection_reduce encountered an invalid projection" in
-  Some (ctx, te)
+  assert false (* TODO *)
 
 (** Let [xuus] be the list [(x1,(u1,u1')); ...; (xn,(un,un'))] where
     [ui]  is well-formed in the context [x1:u1 , ..., x{i-1}:u{i-1} ] and
@@ -316,7 +304,8 @@ and equal env ctx ((_,loc1) as e1) ((_,loc2) as e2) t =
 
         | Tt.Bracket _ -> return ctx (** Strict bracket types *)
 
-        | Tt.Signature xts ->
+        | Tt.Signature xts -> assert false (* TODO *)
+        (*
           let rec fold ctx = begin function
             | [] -> return ctx
             | (p,t)::rem -> (* careful with the type here when we get interdependent fields *)
@@ -326,6 +315,7 @@ and equal env ctx ((_,loc1) as e1) ((_,loc2) as e2) t =
               fold ctx rem
             end
           in fold ctx xts
+        *)
 
         | Tt.Module _ -> Error.impossible ~loc:loc1 "module is not a type"
 
@@ -484,7 +474,8 @@ and equal_whnf env ctx (e1',loc1) (e2',loc2) =
   | Tt.Bracket t1, Tt.Bracket t2 ->
      equal_ty env ctx t1 t2
 
-  | Tt.Signature xts1, Tt.Signature xts2 ->
+  | Tt.Signature xts1, Tt.Signature xts2 -> assert false (* TODO *)
+  (*
     let rec fold ctx xts1 xts2 = match xts1, xts2 with
       | [], [] -> return ctx
       | (_::_),[] | [],(_::_) -> None
@@ -496,8 +487,10 @@ and equal_whnf env ctx (e1',loc1) (e2',loc2) =
         else None
       in
     fold ctx xts1 xts2
+    *)
 
-  | Tt.Module xts1, Tt.Module xts2 ->
+  | Tt.Module xts1, Tt.Module xts2 -> assert false (* TODO *)
+  (*
     let rec fold ctx xts1 xts2 = match xts1, xts2 with
       | [], [] -> return ctx
       | (_::_),[] | [],(_::_) -> None
@@ -510,8 +503,10 @@ and equal_whnf env ctx (e1',loc1) (e2',loc2) =
         else None
       in
     fold ctx xts1 xts2
+    *)
 
-  | Tt.Projection (te1,xts1,p1), Tt.Projection (te2,xts2,p2) ->
+  | Tt.Projection (te1,xts1,p1), Tt.Projection (te2,xts2,p2) -> assert false (* TODO *)
+  (*
     if Name.eq_ident p1 p2
     then
       let rec fold ctx xts1 xts2 = match xts1, xts2 with
@@ -527,6 +522,7 @@ and equal_whnf env ctx (e1',loc1) (e2',loc2) =
       fold ctx xts1 xts2 >>= fun ctx ->
       equal_whnf env ctx te1 te2
     else None
+    *)
 
   | (Tt.Atom _ | Tt.Constant _ | Tt.Lambda _ | Tt.Spine _ |
      Tt.Type | Tt.Prod _ | Tt.Eq _ | Tt.Refl _ | Tt.Inhab | Tt.Bracket _ |

--- a/src/nucleus/equal.mli
+++ b/src/nucleus/equal.mli
@@ -46,5 +46,5 @@ val inhabit_bracket :
 val as_bracket : Environment.t -> Judgement.ty -> Context.t * Tt.ty
 
 (** Convert a type to a signature. *)
-val as_signature : Environment.t -> Judgement.ty -> Context.t * (Name.ident * Name.ident * Tt.ty) list
+val as_signature : Environment.t -> Judgement.ty -> Context.t * Tt.field_types
 

--- a/src/nucleus/equal.mli
+++ b/src/nucleus/equal.mli
@@ -46,5 +46,5 @@ val inhabit_bracket :
 val as_bracket : Environment.t -> Judgement.ty -> Context.t * Tt.ty
 
 (** Convert a type to a signature. *)
-val as_signature : Environment.t -> Judgement.ty -> Context.t * (Name.ident * Tt.ty) list
+val as_signature : Environment.t -> Judgement.ty -> Context.t * (Name.ident * Name.ident * Tt.ty) list
 

--- a/src/nucleus/equal.mli
+++ b/src/nucleus/equal.mli
@@ -24,9 +24,6 @@ val as_eq : Environment.t -> Judgement.ty -> Context.t * Tt.ty * Tt.term * Tt.te
 (** Convert a type to a product. *)
 val as_prod : Environment.t -> Judgement.ty -> Context.t * Tt.ty Tt.ty_abstraction
 
-(** Convert a type to a bracket type. *)
-val as_bracket : Environment.t -> Judgement.ty -> Context.t * Tt.ty
-
 (** Convert a type to a universally quantified equality type by aggresively
     unfolding as many inner products as possible. If we get a bare equality type
     the list of binders is empty (and the call succeeds). *)
@@ -44,3 +41,10 @@ val as_universal_bracket :
 val inhabit_bracket :
   subgoals:bool -> loc:Location.t ->
   Environment.t -> Judgement.ty -> (Context.t * Tt.term) option
+
+(** Convert a type to a bracket type. *)
+val as_bracket : Environment.t -> Judgement.ty -> Context.t * Tt.ty
+
+(** Convert a type to a signature. *)
+val as_signature : Environment.t -> Judgement.ty -> Context.t * (Name.ident * Tt.ty) list
+

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -248,40 +248,16 @@ and infer env (c',loc) =
   | Syntax.Inhab ->
     Error.typing ~loc "cannot infer the type of []"
   
-  | Syntax.Signature xts ->
-    let rec fold ctx xts = function
-      | [] -> Value.return (ctx,List.rev xts)
-      | (x,c)::rem ->
-        check_ty env c >>= fun (ctxt,t) ->
-        let ctx,_ = Context.join ctx ctxt in
-        fold ctx ((x,t)::xts) rem
-      in
-    fold Context.empty [] xts >>= fun (ctx,xts) ->
-    let t = Tt.mk_signature ~loc xts in
-    let typ = Tt.mk_type_ty ~loc in
-    let j = Judgement.mk_term ctx t typ in
-    Value.return_term j
+  | Syntax.Signature xts -> assert false (* TODO *)
 
-  | Syntax.Module xts ->
-    let rec fold ctx xts = function
-      | [] -> Value.return (ctx,List.rev xts)
-      | (x,c)::rem ->
-        infer env c >>= as_term ~loc >>= fun (ctxt,te,t) ->
-        let ctx,_ = Context.join ctx ctxt in
-        fold ctx ((x,t,te)::xts) rem
-      in
-    fold Context.empty [] xts >>= fun (ctx,xts) ->
-    let t = Tt.mk_signature_ty ~loc (List.map (fun (x,t,_) -> x,t) xts) in
-    let te = Tt.mk_module ~loc xts in
-    let j = Judgement.mk_term ctx te t in
-    Value.return_term j
+  | Syntax.Module xts -> assert false (* TODO *)
 
   | Syntax.Projection (c,x) ->
     infer env c >>= as_term ~loc >>= fun (ctx,te,ty) ->
     let jty = Judgement.mk_ty ctx ty in
     let ctxt, xts = Equal.as_signature env jty in
     let ctx, _ = Context.join ctxt ctx in (* ctxt should be based on ctx but everyone is doing this? *)
-    try let _,ty = List.find (fun (y,ty) -> Name.eq_ident x y) xts in
+    try let _,ty = List.find (fun (y,ty) -> Name.eq_ident x y) xts in (* TODO check deps *)
       let te = Tt.mk_projection ~loc te xts x in
       let j = Judgement.mk_term ctx te ty in
       Value.return_term j
@@ -410,19 +386,7 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
                                   (print_ty env t')
      end
 
-  | Syntax.Module xcs ->
-      let ctxt, xts = Equal.as_signature env t_check in
-      let ctx,_ = Context.join ctx_check ctxt in
-      let rec fold ctx res xts xcs = match xts, xcs with
-        | [], [] -> Value.return (ctx, Tt.mk_module ~loc (List.rev res))
-        | (x,t)::xts, (x',c)::xcs ->
-          if Name.eq_ident x x'
-          then check env c (Judgement.mk_ty ctx t) >>= fun (ctx,te) ->
-            fold ctx ((x,t,te)::res) xts xcs
-          else Error.typing ~loc "signature and module field names do not match: %t and %t" (Name.print_ident x) (Name.print_ident x')
-        | _::_, [] | [], _::_ -> Error.typing ~loc "signature and module must have the same number of fields"
-        in
-      fold ctx [] xts xcs
+  | Syntax.Module xcs -> assert false (* TODO *)
 
 and handle_result env {Value.handler_val; handler_ops; handler_finally} r =
   begin match r with

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -252,7 +252,8 @@ and infer env (c',loc) =
 
   | Syntax.Module xts -> assert false (* TODO *)
 
-  | Syntax.Projection (c,x) ->
+  | Syntax.Projection (c,x) -> assert false (* TODO *)
+  (*
     infer env c >>= as_term ~loc >>= fun (ctx,te,ty) ->
     let jty = Judgement.mk_ty ctx ty in
     let ctxt, xts = Equal.as_signature env jty in
@@ -262,6 +263,7 @@ and infer env (c',loc) =
       let j = Judgement.mk_term ctx te ty in
       Value.return_term j
     with | Not_found -> Error.typing ~loc "cannot project non present field %t" (Name.print_ident x)
+  *)
 
 and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty) : (Context.t * Tt.term) Value.result =
   match c' with

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -247,6 +247,45 @@ and infer env (c',loc) =
 
   | Syntax.Inhab ->
     Error.typing ~loc "cannot infer the type of []"
+  
+  | Syntax.Signature xts ->
+    let rec fold ctx xts = function
+      | [] -> Value.return (ctx,List.rev xts)
+      | (x,c)::rem ->
+        check_ty env c >>= fun (ctxt,t) ->
+        let ctx,_ = Context.join ctx ctxt in
+        fold ctx ((x,t)::xts) rem
+      in
+    fold Context.empty [] xts >>= fun (ctx,xts) ->
+    let t = Tt.mk_signature ~loc xts in
+    let typ = Tt.mk_type_ty ~loc in
+    let j = Judgement.mk_term ctx t typ in
+    Value.return_term j
+
+  | Syntax.Module xts ->
+    let rec fold ctx xts = function
+      | [] -> Value.return (ctx,List.rev xts)
+      | (x,c)::rem ->
+        infer env c >>= as_term ~loc >>= fun (ctxt,te,t) ->
+        let ctx,_ = Context.join ctx ctxt in
+        fold ctx ((x,t,te)::xts) rem
+      in
+    fold Context.empty [] xts >>= fun (ctx,xts) ->
+    let t = Tt.mk_signature_ty ~loc (List.map (fun (x,t,_) -> x,t) xts) in
+    let te = Tt.mk_module ~loc xts in
+    let j = Judgement.mk_term ctx te t in
+    Value.return_term j
+
+  | Syntax.Projection (c,x) ->
+    infer env c >>= as_term ~loc >>= fun (ctx,te,ty) ->
+    let jty = Judgement.mk_ty ctx ty in
+    let ctxt, xts = Equal.as_signature env jty in
+    let ctx, _ = Context.join ctxt ctx in (* ctxt should be based on ctx but everyone is doing this? *)
+    try let _,ty = List.find (fun (y,ty) -> Name.eq_ident x y) xts in
+      let te = Tt.mk_projection ~loc te xts x in
+      let j = Judgement.mk_term ctx te ty in
+      Value.return_term j
+    with | Not_found -> Error.typing ~loc "cannot project non present field %t" (Name.print_ident x)
 
 and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty) : (Context.t * Tt.term) Value.result =
   match c' with
@@ -261,7 +300,9 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
   | Syntax.Prod _
   | Syntax.Eq _
   | Syntax.Spine _
-  | Syntax.Bracket _  ->
+  | Syntax.Bracket _
+  | Syntax.Signature _
+  | Syntax.Projection _ ->
     (** this is the [check-infer] rule, which applies for all term formers "foo"
         that don't have a "check-foo" rule *)
 
@@ -368,6 +409,20 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
            | None -> Error.typing ~loc "do not know how to inhabit %t"
                                   (print_ty env t')
      end
+
+  | Syntax.Module xcs ->
+      let ctxt, xts = Equal.as_signature env t_check in
+      let ctx,_ = Context.join ctx_check ctxt in
+      let rec fold ctx res xts xcs = match xts, xcs with
+        | [], [] -> Value.return (ctx, Tt.mk_module ~loc (List.rev res))
+        | (x,t)::xts, (x',c)::xcs ->
+          if Name.eq_ident x x'
+          then check env c (Judgement.mk_ty ctx t) >>= fun (ctx,te) ->
+            fold ctx ((x,t,te)::res) xts xcs
+          else Error.typing ~loc "signature and module field names do not match: %t and %t" (Name.print_ident x) (Name.print_ident x')
+        | _::_, [] | [], _::_ -> Error.typing ~loc "signature and module must have the same number of fields"
+        in
+      fold ctx [] xts xcs
 
 and handle_result env {Value.handler_val; handler_ops; handler_finally} r =
   begin match r with

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -322,6 +322,7 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
   | Syntax.Spine _
   | Syntax.Bracket _
   | Syntax.Signature _
+  | Syntax.Module _
   | Syntax.Projection _ ->
     (** this is the [check-infer] rule, which applies for all term formers "foo"
         that don't have a "check-foo" rule *)
@@ -429,8 +430,6 @@ and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty
            | None -> Error.typing ~loc "do not know how to inhabit %t"
                                   (print_ty env t')
      end
-
-  | Syntax.Module xcs -> assert false (* TODO *)
 
 and handle_result env {Value.handler_val; handler_ops; handler_finally} r =
   begin match r with

--- a/src/nucleus/eval.ml
+++ b/src/nucleus/eval.ml
@@ -266,20 +266,46 @@ and infer env (c',loc) =
       in
     fold env Context.empty [] [] xcs
 
-  | Syntax.Module xts -> assert false (* TODO *)
+  | Syntax.Module xcs ->
+    let rec fold tenv venv ctx ys vs xtes = function
+      | [] ->
+        let xtes = List.rev xtes in
+        let te = Tt.mk_module ~loc xtes in
+        let ty = Tt.mk_signature_ty ~loc (List.map (fun (l,x,t,_) -> l,x,t) xtes) in
+        let ctx = Context.abstract ~loc ctx ys in
+        let j = Judgement.mk_term ctx te ty in
+        Value.return_term j
+      | (l,x,Some c,c')::rem ->
+        check_ty tenv c >>= fun ((ctxt,t) as jt) ->
+        let y,tenv = Environment.add_fresh ~loc tenv x jt in
+        let t = Tt.abstract_ty ys 0 t in
+        let ctx,_ = Context.join ctx ctxt in
+        let t' = Tt.instantiate_ty vs 0 t in
+        check venv c' (ctx,t') >>= fun (ctx,te) ->
+        let jte = Judgement.mk_term ctx te t' in
+        let venv = Environment.add_bound x (Value.Term jte) venv in
+        fold tenv venv ctx (y::ys) (te::vs) ((l,x,t,te)::xtes) rem
+      | (l,x,None,c)::rem ->
+        infer venv c >>= as_term ~loc >>= fun (ctxt,te,ty) ->
+        let ctx,_ = Context.join ctx ctxt in
+        let jty = Judgement.mk_ty ctx ty in
+        let t = Tt.abstract_ty ys 0 ty in
+        let y,tenv = Environment.add_fresh ~loc tenv x jty in
+        let jte = Judgement.mk_term ctx te ty in
+        let venv = Environment.add_bound x (Value.Term jte) venv in
+        fold tenv venv ctx (y::ys) (te::vs) ((l,x,t,te)::xtes) rem
+      in
+    fold env env Context.empty [] [] [] xcs
 
-  | Syntax.Projection (c,x) -> assert false (* TODO *)
-  (*
+  | Syntax.Projection (c,p) ->
     infer env c >>= as_term ~loc >>= fun (ctx,te,ty) ->
     let jty = Judgement.mk_ty ctx ty in
     let ctxt, xts = Equal.as_signature env jty in
     let ctx, _ = Context.join ctxt ctx in (* ctxt should be based on ctx but everyone is doing this? *)
-    try let _,ty = List.find (fun (y,ty) -> Name.eq_ident x y) xts in (* TODO check deps *)
-      let te = Tt.mk_projection ~loc te xts x in
-      let j = Judgement.mk_term ctx te ty in
-      Value.return_term j
-    with | Not_found -> Error.typing ~loc "cannot project non present field %t" (Name.print_ident x)
-  *)
+    let ty = Tt.field_type ~loc xts te p in
+    let te = Tt.mk_projection ~loc te xts p in
+    let j = Judgement.mk_term ctx te ty in
+    Value.return_term j
 
 and check env ((c',loc) as c) (((ctx_check, t_check') as t_check) : Judgement.ty) : (Context.t * Tt.term) Value.result =
   match c' with

--- a/src/nucleus/hint.ml
+++ b/src/nucleus/hint.ml
@@ -20,7 +20,10 @@ let has_head_name = function
            | Pattern.Key_Eq
            | Pattern.Key_Refl
            | Pattern.Key_Inhab
-           | Pattern.Key_Bracket -> false
+           | Pattern.Key_Bracket
+           | Pattern.Key_Signature
+           | Pattern.Key_Module
+           | Pattern.Key_Projection -> false
      end
 
 (** Convert a term [e] of type [t] to a pattern with respect to the
@@ -105,6 +108,12 @@ let rec of_term env pvars ((e',loc) as e) t =
       | Pattern.Ty (Pattern.Term _) -> original
       | _ -> pvars, (Pattern.Bracket t)
     end
+
+  | Tt.Signature _ -> original
+
+  | Tt.Module _ -> original
+
+  | Tt.Projection _ -> original
 
 and of_ty env pvars (Tt.Ty t) =
   let pvars, t = of_term env pvars t Tt.typ in

--- a/src/nucleus/pattern.ml
+++ b/src/nucleus/pattern.ml
@@ -46,6 +46,9 @@ type hint_key =
   | Key_Refl
   | Key_Inhab
   | Key_Bracket
+  | Key_Signature
+  | Key_Module
+  | Key_Projection
 
 type general_key = hint_key option * hint_key option * hint_key option
 
@@ -62,6 +65,9 @@ let rec term_key_opt (e',loc) =
   | Tt.Refl _ -> Some Key_Refl
   | Tt.Inhab -> Some Key_Inhab
   | Tt.Bracket _ -> Some Key_Bracket
+  | Tt.Signature _ -> Some Key_Signature
+  | Tt.Module _ -> Some Key_Module
+  | Tt.Projection _ -> Some Key_Projection
 
 let term_key e =
   match term_key_opt e with
@@ -174,6 +180,9 @@ let print_key ?max_level k ppf =
   | Key_Refl -> Print.print ?max_level ppf "%s" "Refl"
   | Key_Inhab -> Print.print ?max_level ppf "%s" "Inhab"
   | Key_Bracket -> Print.print ?max_level ppf "%s" "Bracket"
+  | Key_Signature -> Print.print ?max_level ppf "%s" "Signature"
+  | Key_Module -> Print.print ?max_level ppf "%s" "Module"
+  | Key_Projection -> Print.print ?max_level ppf "%s" "Projection"
 
 
 let print_key_opt ?max_level k ppf =

--- a/src/nucleus/pattern.mli
+++ b/src/nucleus/pattern.mli
@@ -62,6 +62,9 @@ type hint_key =
   | Key_Refl
   | Key_Inhab
   | Key_Bracket
+  | Key_Signature
+  | Key_Module
+  | Key_Projection
 
 type general_key = hint_key option * hint_key option * hint_key option
 

--- a/src/nucleus/simplify.ml
+++ b/src/nucleus/simplify.ml
@@ -196,7 +196,8 @@ and project ~loc te xts p =
       let sig2 = Tt.mk_signature ~loc xts in
       if Tt.alpha_equal sig1 sig2
       then
-        assert false (* TODO *)
+        let te = Tt.field_value ~loc xtes p in
+        term te
       else Tt.mk_projection ~loc te xts p
     | Tt.Constant _
     | Tt.Lambda _

--- a/src/nucleus/simplify.mli
+++ b/src/nucleus/simplify.mli
@@ -1,6 +1,6 @@
 (** Simplification of expressions and types. *)
 
-(** [termimplify] performs beta reductions when they result in a term
+(** [term] performs beta reductions when they result in a term
     that does not increase in size, for instance if the bound variable
     appears at most once in the body of the function, or if the argument
     is an atomic expression (a variable or a constant). *)

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -15,6 +15,9 @@ and term' =
   | Refl of ty * term
   | Inhab
   | Bracket of ty
+  | Signature of (Name.ident * ty) list
+  | Module of (Name.ident * ty * term) list
+  | Projection of term * (Name.ident * ty) list * Name.ident
 
 and ty = Ty of term
 
@@ -56,6 +59,10 @@ let mk_refl ~loc t e = Refl (t, e), loc
 let mk_inhab ~loc = Inhab, loc
 let mk_bracket ~loc t = Bracket t, loc
 
+let mk_signature ~loc lst = Signature lst, loc
+let mk_module ~loc lst = Module lst, loc
+let mk_projection ~loc te xts x = Projection (te,xts,x), loc
+
 (** Convert a term to a type. *)
 let ty e = Ty e
 
@@ -63,6 +70,7 @@ let mk_eq_ty ~loc t e1 e2 = ty (mk_eq ~loc t e1 e2)
 let mk_prod_ty ~loc xts t = ty (mk_prod ~loc xts t)
 let mk_type_ty ~loc = ty (mk_type ~loc)
 let mk_bracket_ty ~loc t = ty (mk_bracket ~loc t)
+let mk_signature_ty ~loc lst = ty (mk_signature ~loc lst)
 
 (** The [Type] constant, without a location. *)
 let typ = Ty (mk_type ~loc:Location.unknown)
@@ -141,6 +149,19 @@ and instantiate es depth ((e',loc) as e) =
     | Bracket t ->
       let t = instantiate_ty es depth t in
       Bracket t, loc
+
+    | Signature xts ->
+      let xts = List.map (fun (x,t) -> x,instantiate_ty es depth t) xts in
+      Signature xts, loc
+
+    | Module xts ->
+      let xts = List.map (fun (x,t,te) -> x,instantiate_ty es depth t,instantiate es depth te) xts in
+      Module xts, loc
+
+    | Projection (te,xts,p) ->
+      let te = instantiate es depth te in
+      let xts = List.map (fun (x,t) -> x,instantiate_ty es depth t) xts in
+      Projection (te,xts,p), loc
 
 and instantiate_ty es depth (Ty t) =
   let t = instantiate es depth t
@@ -223,6 +244,18 @@ and abstract xs depth ((e',loc) as e) =
     let t = abstract_ty xs depth t in
     Bracket t, loc
 
+  | Signature xts ->
+    let xts = List.map (fun (x,t) -> x,abstract_ty xs depth t) xts in
+    Signature xts, loc
+
+  | Module xts ->
+    let xts = List.map (fun (x,t,te) -> x,abstract_ty xs depth t,abstract xs depth te) xts in
+    Module xts, loc
+
+  | Projection (te,xts,p) ->
+    let te = abstract xs depth te in
+    let xts = List.map (fun (x,t) -> x,abstract_ty xs depth t) xts in
+    Projection (te,xts,p), loc
 
 and abstract_ty xs depth (Ty t) =
   let t = abstract xs depth t
@@ -288,6 +321,19 @@ let rec shift k lvl ((e',loc) as e) =
       let t = shift_ty k lvl t in
         Bracket t, loc
 
+    | Signature xts ->
+      let xts = List.map (fun (x,t) -> x,shift_ty k lvl t) xts in
+      Signature xts, loc
+
+    | Module xts ->
+      let xts = List.map (fun (x,t,te) -> x,shift_ty k lvl t,shift k lvl te) xts in
+      Module xts, loc
+
+    | Projection (te,xts,p) ->
+      let te = shift k lvl te in
+      let xts = List.map (fun (x,t) -> x,shift_ty k lvl t) xts in
+      Projection (te,xts,p), loc
+
 and shift_ty k lvl (Ty t) =
   let t = shift k lvl t in
     Ty t
@@ -346,6 +392,12 @@ let rec occurs k (e',_) =
   | Inhab -> 0
   | Bracket t ->
     occurs_ty k t
+  | Signature xts ->
+    List.fold_left (fun i (_,e) -> i + occurs_ty k e) 0 xts
+  | Module xts ->
+    List.fold_left (fun i (_,e,e') -> i + occurs_ty k e + occurs k e') 0 xts
+  | Projection (te,xts,p) ->
+    List.fold_left (fun i (_,e) -> i + occurs_ty k e) (occurs k te) xts
 
 and occurs_ty k (Ty t) = occurs k t
 
@@ -369,6 +421,13 @@ let alpha_equal_abstraction alpha_equal_u alpha_equal_v (xus, v) (xus', v') =
   in
   eq xus xus' &&
   alpha_equal_v v v'
+
+let rec alpha_equal_list equal_e es es' =
+  match es, es' with
+  | [], [] -> true
+  | e :: es, e' :: es' ->
+    equal_e e e' && alpha_equal_list equal_e es es'
+  | ([],_::_) | ((_::_),[]) -> false
 
 let rec alpha_equal (e1,_) (e2,_) =
   e1 == e2 || (* a shortcut in case the terms are identical *)
@@ -409,21 +468,36 @@ let rec alpha_equal (e1,_) (e2,_) =
 
     | Inhab, Inhab -> true
 
+    | Signature xts1, Signature xts2 ->
+      alpha_equal_list (fun (x1,t1) (x2,t2) ->
+          Name.eq_ident x1 x2 &&
+          alpha_equal_ty t1 t2)
+        xts1 xts2
+
+    | Module xts1, Module xts2 ->
+      alpha_equal_list (fun (x1,t1,te1) (x2,t2,te2) ->
+          Name.eq_ident x1 x2 &&
+          alpha_equal_ty t1 t2 &&
+          alpha_equal te1 te2)
+        xts1 xts2
+
+    | Projection (te1,xts1,p1), Projection (te2,xts2,p2) ->
+      Name.eq_ident p1 p2 &&
+      alpha_equal te1 te2 &&
+      alpha_equal_list (fun (x1,t1) (x2,t2) ->
+          Name.eq_ident x1 x2 &&
+          alpha_equal_ty t1 t2)
+        xts1 xts2
+
     | (Atom _ | Bound _ | Constant _ | Lambda _ | Spine _ |
-        Type | Prod _ | Eq _ | Refl _ | Bracket _ | Inhab), _ ->
+        Type | Prod _ | Eq _ | Refl _ | Bracket _ | Inhab |
+        Signature _ | Module _ | Projection _), _ ->
       false
   end
 
 and alpha_equal_ty (Ty t1) (Ty t2) = alpha_equal t1 t2
 
 and alpha_equal_term_ty (e, t) (e', t') = alpha_equal e e' && alpha_equal_ty t t'
-
-and alpha_equal_list equal_e es es' =
-  match es, es' with
-  | [], [] -> true
-  | e :: es, e' :: es' ->
-    equal_e e e' && alpha_equal_list equal_e es es'
-  | ([],_::_) | ((_::_),[]) -> false
 
 
 (****** Printing routines *****)
@@ -497,6 +571,23 @@ let rec print_term ?max_level xs (e,_) ppf =
         print ~at_level:0 "[[%t]]"
           (print_ty xs t)
 
+      | Signature xts -> (* XXX someone who knows prettyprinting do this properly *)
+        print ~at_level:0 "P{%t}"
+          (Print.sequence (fun (x,t) fmt -> Print.print fmt "%t : %t"
+              (Name.print_ident x)
+              (print_ty ~max_level:1 xs t))
+            "," xts)
+
+      | Module xts ->
+        print ~at_level:0 "P{%t}"
+          (Print.sequence (fun (x,t,te) fmt -> Print.print fmt "%t := %t :: %t"
+              (Name.print_ident x)
+              (print_term ~max_level:1 xs te)
+              (print_ty ~max_level:1 xs t))
+            "," xts)
+
+      | Projection (te,xts,p) -> print ~at_level:1 "%t" (print_projection xs te xts p)
+
 and print_ty ?max_level xs (Ty t) ppf = print_term ?max_level xs t ppf
 
 (** [print_lambda a e t ppf] prints a lambda abstraction using formatter [ppf]. *)
@@ -551,6 +642,20 @@ and print_spine xs e (yts, u) es ppf =
   else
     spine_noannot ppf
 
+and print_projection xs te xts p ppf = if !Config.annotate
+  then
+    Print.print ppf "@[<hov 2>%t@ @@{%t}.%t@]"
+      (print_term ~max_level:0 xs te)
+      (Print.sequence (fun (x,t) ppf -> Print.print ppf "%t : %t"
+          (Name.print_ident x)
+          (print_ty ~max_level:1 xs t))
+        "," xts)
+      (Name.print_ident p)
+  else
+    Print.print ppf "@[<hov 2>%t@ .%t@]"
+      (print_term ~max_level:0 xs te)
+      (Name.print_ident p)
+
 and print_binder xs (x, t) ppf =
   Print.print ppf "(%t :@ %t)"
         (Name.print_ident x)
@@ -570,3 +675,4 @@ let print_constsig ?max_level xs (rxus, t) ppf =
   match rxus with
   | [] -> print_u "" xs ppf
   | _::_ -> Name.print_binders print_xs (print_u " ") xs rxus ppf
+

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -15,13 +15,17 @@ and term' =
   | Refl of ty * term
   | Inhab
   | Bracket of ty
-  | Signature of (Name.ident * Name.ident * ty) list
-  | Module of (Name.ident * Name.ident * ty * term) list
-  | Projection of term * (Name.ident * Name.ident * ty) list * Name.ident
+  | Signature of field_types
+  | Module of field_defs
+  | Projection of term * field_types * Name.ident
 
 and ty = Ty of term
 
 and 'a ty_abstraction = (ty, 'a) abstraction
+
+and field_types = (Name.ident * Name.ident * ty) list
+
+and field_defs = (Name.ident * Name.ident * ty * term) list
 
 type constsig = ((bool * ty), ty) abstraction
 
@@ -481,6 +485,21 @@ and occurs_term_ty k (e, t) =
   occurs k e + occurs_ty k t
 
 let occurs_ty_abstraction f = occurs_abstraction occurs_ty f
+
+
+(****** Module stuff ********)
+
+let field_value ~loc xtes p =
+  let rec fold vs = function
+    | [] -> Error.runtime "Tt.field_value: field %t not found" (Name.print_ident p)
+    | (l,x,t,te)::rem ->
+      let te = instantiate vs 0 te in
+      if Name.eq_ident p l
+      then te
+      else fold (te::vs) rem
+    in
+  fold [] xtes
+
 
 (****** Alpha equality ******)
 

--- a/src/nucleus/tt.ml
+++ b/src/nucleus/tt.ml
@@ -487,20 +487,6 @@ and occurs_term_ty k (e, t) =
 let occurs_ty_abstraction f = occurs_abstraction occurs_ty f
 
 
-(****** Module stuff ********)
-
-let field_value ~loc xtes p =
-  let rec fold vs = function
-    | [] -> Error.runtime "Tt.field_value: field %t not found" (Name.print_ident p)
-    | (l,x,t,te)::rem ->
-      let te = instantiate vs 0 te in
-      if Name.eq_ident p l
-      then te
-      else fold (te::vs) rem
-    in
-  fold [] xtes
-
-
 (****** Alpha equality ******)
 
 (* Currently, the only difference between alpha and structural equality is that
@@ -806,4 +792,30 @@ let print_constsig ?max_level xs (rxus, t) ppf =
   match rxus with
   | [] -> print_u "" xs ppf
   | _::_ -> Name.print_binders print_xs (print_u " ") xs rxus ppf
+
+
+(****** Module stuff ********)
+
+let field_value ~loc xtes p =
+  let rec fold vs = function
+    | [] -> Error.runtime "Tt.field_value: field %t not found" (Name.print_ident p)
+    | (l,x,t,te)::rem ->
+      let te = instantiate vs 0 te in
+      if Name.eq_ident p l
+      then te
+      else fold (te::vs) rem
+    in
+  fold [] xtes
+
+let field_type ~loc xts e p =
+  let rec fold vs = function
+    | [] -> Error.typing "%t has no field %t" (print_term [] e) (Name.print_ident p)
+    | (l,x,t)::rem ->
+      if Name.eq_ident p l
+      then instantiate_ty vs 0 t
+      else
+        let el = mk_projection ~loc e xts l in
+        fold (el::vs) rem
+    in
+  fold [] xts
 

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -65,14 +65,14 @@ and term' = private
   | Bracket of ty
 
   (** signature, also known as record type *)
-  | Signature of (Name.ident * Name.ident * ty) list
+  | Signature of field_types
 
   (** module, also known as record term *)
-  | Module of (Name.ident * Name.ident * ty * term) list
+  | Module of field_defs
 
   (** a projection [e {x1:t1, ..., xn:tn} .xi] means that we project field [xi] of [e] and [e] has type [{x1:t1, ..., xn:tn}].
       Currently field types do not depend on other fields so the result has type [ti]. *)
-  | Projection of term * (Name.ident * Name.ident * ty) list * Name.ident
+  | Projection of term * field_types * Name.ident
 
 (** Since we have [Type : Type] we do not distinguish terms from types,
     so the type of type [ty] is just a synonym for the type of terms.
@@ -82,6 +82,10 @@ and ty = private
 
 (** A ['a ty_abstraction] is a n abstraction where the [a1, ..., an] are types *)
 and 'a ty_abstraction = (ty, 'a) abstraction
+
+and field_types = (Name.ident * Name.ident * ty) list
+
+and field_defs = (Name.ident * Name.ident * ty * term) list
 
 (** The signature of a constant. The booleans indicate whether the arguments
     should be eagerly reduced. *)
@@ -103,10 +107,10 @@ val mk_refl: loc:Location.t -> ty -> term -> term
 val mk_bracket: loc:Location.t -> ty -> term
 val mk_bracket_ty: loc:Location.t -> ty -> ty
 val mk_inhab: loc:Location.t -> term
-val mk_signature : loc:Location.t -> (Name.ident * Name.ident * ty) list -> term
-val mk_signature_ty : loc:Location.t -> (Name.ident * Name.ident * ty) list -> ty
-val mk_module : loc:Location.t -> (Name.ident * Name.ident * ty * term) list -> term
-val mk_projection : loc:Location.t -> term -> (Name.ident * Name.ident * ty) list -> Name.ident -> term
+val mk_signature : loc:Location.t -> field_types -> term
+val mk_signature_ty : loc:Location.t -> field_types -> ty
+val mk_module : loc:Location.t -> field_defs -> term
+val mk_projection : loc:Location.t -> term -> field_types -> Name.ident -> term
 
 
 (** Coerce a value to a type (does not check whether this is legal). *)
@@ -161,6 +165,13 @@ val occurs_term_ty: Syntax.bound -> term * ty -> int
 val occurs_ty_abstraction:
   (Syntax.bound -> 'a -> int) ->
   Syntax.bound -> 'a ty_abstraction -> int
+
+
+(** Module stuff *)
+
+(** [field_value defs p] is [defs.p] with all bound variables instantiated appropriately. *)
+val field_value : loc:Location.t -> field_defs -> Name.ident -> term
+
 
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -64,6 +64,16 @@ and term' = private
   (** bracket type *)
   | Bracket of ty
 
+  (** signature, also known as record type *)
+  | Signature of (Name.ident * ty) list
+
+  (** module, also known as record term *)
+  | Module of (Name.ident * ty * term) list
+
+  (** a projection [e {x1:t1, ..., xn:tn} .xi] means that we project field [xi] of [e] and [e] has type [{x1:t1, ..., xn:tn}].
+      Currently field types do not depend on other fields so the result has type [ti]. *)
+  | Projection of term * (Name.ident * ty) list * Name.ident
+
 (** Since we have [Type : Type] we do not distinguish terms from types,
     so the type of type [ty] is just a synonym for the type of terms.
     However, we tag types with the [Ty] constructor to avoid nasty bugs. *)
@@ -93,6 +103,11 @@ val mk_refl: loc:Location.t -> ty -> term -> term
 val mk_bracket: loc:Location.t -> ty -> term
 val mk_bracket_ty: loc:Location.t -> ty -> ty
 val mk_inhab: loc:Location.t -> term
+val mk_signature : loc:Location.t -> (Name.ident * ty) list -> term
+val mk_signature_ty : loc:Location.t -> (Name.ident * ty) list -> ty
+val mk_module : loc:Location.t -> (Name.ident * ty * term) list -> term
+val mk_projection : loc:Location.t -> term -> (Name.ident * ty) list -> Name.ident -> term
+
 
 (** Coerce a value to a type (does not check whether this is legal). *)
 val ty : term -> ty

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -172,6 +172,8 @@ val occurs_ty_abstraction:
 (** [field_value defs p] is [defs.p] with all bound variables instantiated appropriately. *)
 val field_value : loc:Location.t -> field_defs -> Name.ident -> term
 
+(** [field_type tys e p] when [e : {tys}] is the type of [e.p] *)
+val field_type : loc:Location.t -> field_types -> term -> Name.ident -> ty
 
 (** [alpha_equal e1 e2] returns [true] if term [e1] and [e2] are alpha equal. *)
 val alpha_equal: term -> term -> bool

--- a/src/nucleus/tt.mli
+++ b/src/nucleus/tt.mli
@@ -65,14 +65,14 @@ and term' = private
   | Bracket of ty
 
   (** signature, also known as record type *)
-  | Signature of (Name.ident * ty) list
+  | Signature of (Name.ident * Name.ident * ty) list
 
   (** module, also known as record term *)
-  | Module of (Name.ident * ty * term) list
+  | Module of (Name.ident * Name.ident * ty * term) list
 
   (** a projection [e {x1:t1, ..., xn:tn} .xi] means that we project field [xi] of [e] and [e] has type [{x1:t1, ..., xn:tn}].
       Currently field types do not depend on other fields so the result has type [ti]. *)
-  | Projection of term * (Name.ident * ty) list * Name.ident
+  | Projection of term * (Name.ident * Name.ident * ty) list * Name.ident
 
 (** Since we have [Type : Type] we do not distinguish terms from types,
     so the type of type [ty] is just a synonym for the type of terms.
@@ -103,10 +103,10 @@ val mk_refl: loc:Location.t -> ty -> term -> term
 val mk_bracket: loc:Location.t -> ty -> term
 val mk_bracket_ty: loc:Location.t -> ty -> ty
 val mk_inhab: loc:Location.t -> term
-val mk_signature : loc:Location.t -> (Name.ident * ty) list -> term
-val mk_signature_ty : loc:Location.t -> (Name.ident * ty) list -> ty
-val mk_module : loc:Location.t -> (Name.ident * ty * term) list -> term
-val mk_projection : loc:Location.t -> term -> (Name.ident * ty) list -> Name.ident -> term
+val mk_signature : loc:Location.t -> (Name.ident * Name.ident * ty) list -> term
+val mk_signature_ty : loc:Location.t -> (Name.ident * Name.ident * ty) list -> ty
+val mk_module : loc:Location.t -> (Name.ident * Name.ident * ty * term) list -> term
+val mk_projection : loc:Location.t -> term -> (Name.ident * Name.ident * ty) list -> Name.ident -> term
 
 
 (** Coerce a value to a type (does not check whether this is legal). *)

--- a/src/parser/desugar.ml
+++ b/src/parser/desugar.ml
@@ -174,6 +174,38 @@ let rec comp constants bound ((c',loc) as c) =
     | Input.Inhab ->
       [], Syntax.Inhab
 
+    | Input.Signature lst ->
+      let rec fold xts = function
+        | [] -> List.rev xts
+        | (x,c)::rem ->
+          if List.mem_assoc x xts
+          then
+            Error.syntax ~loc "Field %t appears more than once" (Name.print_ident x)
+          else
+            let c = comp constants bound c in
+            fold ((x,c)::xts) rem
+        in
+      let xts = fold [] lst in
+      [], Syntax.Signature xts
+
+    | Input.Module lst ->
+      let rec fold xts = function
+        | [] -> List.rev xts
+        | (x,c)::rem ->
+          if List.mem_assoc x xts
+          then
+            Error.syntax ~loc "Field %t appears more than once" (Name.print_ident x)
+          else
+            let c = comp constants bound c in
+            fold ((x,c)::xts) rem
+        in
+      let xts = fold [] lst in
+      [], Syntax.Module xts
+
+    | Input.Projection (c,x) ->
+      let c = comp constants bound c in
+      [], Syntax.Projection (c,x)
+
     | (Input.Var _ | Input.Type | Input.Function _ | Input.Handler _) ->
       let w, e = expr constants bound c in
       w, Syntax.Return e
@@ -301,7 +333,7 @@ and expr constants bound ((e', loc) as e) =
      Input.Unhint _ | Input.Bracket _ | Input.Inhab | Input.Ascribe _ | Input.Lambda _ |
      Input.Spine _ | Input.Prod _ | Input.Eq _ | Input.Refl _ | Input.Operation _ |
      Input.Whnf _ | Input.Apply _ | Input.Handle _ | Input.With _ |
-     Input.Typeof _ | Input.Assume _ | Input.Where _) ->
+     Input.Typeof _ | Input.Assume _ | Input.Where _ | Input.Signature _ | Input.Module _ | Input.Projection _) ->
     let x = Name.fresh_candy ()
     and c = comp constants bound e in
     [(x,c)], (Syntax.Bound 0, loc)

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -36,6 +36,9 @@ and term' =
   | Refl of comp
   | Bracket of comp
   | Inhab
+  | Signature of (Name.ident * ty) list
+  | Module of (Name.ident * comp) list
+  | Projection of comp * Name.ident
 
 (** Sugared types *)
 and ty = term

--- a/src/parser/input.mli
+++ b/src/parser/input.mli
@@ -36,8 +36,8 @@ and term' =
   | Refl of comp
   | Bracket of comp
   | Inhab
-  | Signature of (Name.ident * ty) list
-  | Module of (Name.ident * comp) list
+  | Signature of (Name.ident * Name.ident option * ty) list
+  | Module of (Name.ident * Name.ident option * ty option * comp) list
   | Projection of comp * Name.ident
 
 (** Sugared types *)

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -4,6 +4,7 @@ open Ulexbuf
 
 let reserved = [
   ("Axiom", AXIOM) ;
+  ("as", AS) ;
   ("assume", ASSUME) ;
   ("and", AND) ;
   ("beta", BETA) ;

--- a/src/parser/lexer.ml
+++ b/src/parser/lexer.ml
@@ -96,11 +96,14 @@ and token_aux ({ stream; pos_end; end_of_input; line_limit } as lexbuf) =
   | "[]"                     -> f (); LRBRACK
   | '['                      -> f (); LBRACK
   | ']'                      -> f (); RBRACK
+  | '{'                      -> f (); LBRACE
+  | '}'                      -> f (); RBRACE
   | ":="                     -> f (); COLONEQ
   | "::"                     -> f (); DCOLON
   | ':'                      -> f (); COLON
   | ','                      -> f (); COMMA
   | ';'                      -> f (); SEMICOLON
+  | '.', name                -> f (); PROJECTION (let s = lexeme lexbuf in String.sub s 1 (String.length s - 1))
   | '.'                      -> f (); g (); DOT
   | '_'                      -> f (); UNDERSCORE
   | '|'                      -> f (); BAR

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -6,7 +6,7 @@
 %token TYPE
 %token UNDERSCORE
 %token <string> NAME
-%token LPAREN RPAREN LBRACK RBRACK LRBRACK LLBRACK RRBRACK
+%token LPAREN RPAREN LBRACK RBRACK LRBRACK LLBRACK RRBRACK LBRACE RBRACE
 %token DCOLON COLON SEMICOLON COMMA DOT
 %token ARROW
 %token EQEQ
@@ -23,6 +23,7 @@
 %token ASSUME
 %token WHERE
 %token <string> OPERATION
+%token <string> PROJECTION
 %token ENVIRONMENT HELP QUIT
 %token <int> VERBOSITY
 %token <string> QUOTED_STRING
@@ -118,6 +119,7 @@ plain_app_term:
   | e=plain_simple_term                             { e }
   | e=simple_term es=nonempty_list(simple_term)     { Spine (e, es) }
   | e1=simple_term APPLY e2=app_term                { Apply (e1, e2) }
+  | e1=simple_term p=PROJECTION                     { Projection(e1,Name.make p) }
   | WHNF t=simple_term                              { Whnf t }
   | TYPEOF t=simple_term                            { Typeof t }
   | REFL e=simple_term                              { Refl e }
@@ -130,6 +132,10 @@ plain_simple_term:
   | x=var_name                                      { Var x }
   | LPAREN e=plain_term RPAREN                      { e }
   | LLBRACK e=term RRBRACK                          { Bracket e }
+  | LBRACE lst=separated_nonempty_list(COMMA, typed_names) RBRACE
+        { Signature (List.concat lst) }
+  | LBRACE lst=separated_nonempty_list(COMMA, let_clause) RBRACE
+        { Module lst }
 
 var_name:
   | NAME { Name.make $1 }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -158,7 +158,8 @@ typed_names:
   | xs=name+ COLON t=ty_term  { List.map (fun x -> (x, t)) xs }
 
 signature_clause:
-  | x=name COLON t=ty_term { (x,None,t) }
+  | x=name COLON t=ty_term           { (x,None  ,t) }
+  | x=name AS y=name COLON t=ty_term { (x,Some y,t) }
 
 module_clause :
   | x=name COLONEQ c=term                           { (x,None  ,None  ,c) }

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -13,7 +13,7 @@
 %token REFL
 %token TOPLET TOPCHECK TOPBETA TOPETA TOPHINT TOPINHABIT
 %token TOPUNHINT
-%token LET COLONEQ AND IN
+%token LET AS COLONEQ AND IN
 %token BETA ETA HINT INHABIT
 %token UNHINT
 %token HANDLE HANDLER WITH BAR VAL FINALLY END
@@ -132,9 +132,9 @@ plain_simple_term:
   | x=var_name                                      { Var x }
   | LPAREN e=plain_term RPAREN                      { e }
   | LLBRACK e=term RRBRACK                          { Bracket e }
-  | LBRACE lst=separated_nonempty_list(COMMA, typed_names) RBRACE
-        { Signature (List.concat lst) }
-  | LBRACE lst=separated_nonempty_list(COMMA, let_clause) RBRACE
+  | LBRACE lst=separated_nonempty_list(COMMA, signature_clause) RBRACE
+        { Signature lst }
+  | LBRACE lst=separated_nonempty_list(COMMA, module_clause) RBRACE
         { Module lst }
 
 var_name:
@@ -156,6 +156,15 @@ typed_binder:
 
 typed_names:
   | xs=name+ COLON t=ty_term  { List.map (fun x -> (x, t)) xs }
+
+signature_clause:
+  | x=name COLON t=ty_term { (x,None,t) }
+
+module_clause :
+  | x=name COLONEQ c=term                           { (x,None  ,None  ,c) }
+  | x=name AS y=name COLONEQ c=term                 { (x,Some y,None  ,c) }
+  | x=name COLON t=ty_term COLONEQ c=term           { (x,None  ,Some t,c) }
+  | x=name AS y=name COLON t=ty_term COLONEQ c=term { (x,Some y,Some t,c) }
 
 binder:
   | LBRACK lst=separated_nonempty_list(COMMA, maybe_typed_names) RBRACK

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -41,6 +41,9 @@ and comp' =
   | Refl of comp
   | Bracket of comp
   | Inhab
+  | Signature of (Name.ident * comp) list
+  | Module of (Name.ident * comp) list
+  | Projection of comp * Name.ident
 
 and handler = {
   handler_val: (Name.ident * comp) option;
@@ -183,6 +186,18 @@ let rec shift_comp k lvl (c', loc) =
         Bracket c
 
     | Inhab -> Inhab
+
+    | Signature lst ->
+        let lst = List.map (fun (x,c) -> x,shift_comp k lvl c) lst in
+        Signature lst
+
+    | Module lst ->
+        let lst = List.map (fun (x,c) -> x,shift_comp k lvl c) lst in
+        Module lst
+
+    | Projection (c,x) ->
+        let c = shift_comp k lvl c in
+        Projection (c,x)
   in
   c', loc
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -41,8 +41,8 @@ and comp' =
   | Refl of comp
   | Bracket of comp
   | Inhab
-  | Signature of (Name.ident * comp) list
-  | Module of (Name.ident * comp) list
+  | Signature of (Name.ident * Name.ident * comp) list
+  | Module of (Name.ident * Name.ident * comp option * comp) list
   | Projection of comp * Name.ident
 
 and handler = {
@@ -67,6 +67,11 @@ and toplevel' =
   | Quit (** quit the toplevel *)
   | Help (** print help *)
   | Environment (** print the current environment *)
+
+
+let opt_map f = function
+  | None -> None
+  | Some x -> Some (f x)
 
 let rec shift_comp k lvl (c', loc) =
   let c' =
@@ -188,11 +193,11 @@ let rec shift_comp k lvl (c', loc) =
     | Inhab -> Inhab
 
     | Signature lst ->
-        let lst = List.map (fun (x,c) -> x,shift_comp k lvl c) lst in
+        let lst = List.map (fun (x,x',c) -> x,x',shift_comp k lvl c) lst in
         Signature lst
 
     | Module lst ->
-        let lst = List.map (fun (x,c) -> x,shift_comp k lvl c) lst in
+        let lst = List.map (fun (x,x',ty,c) -> x,x',opt_map (shift_comp k lvl) ty,shift_comp k lvl c) lst in
         Module lst
 
     | Projection (c,x) ->

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -41,6 +41,9 @@ and comp' =
   | Refl of comp
   | Bracket of comp
   | Inhab
+  | Signature of (Name.ident * comp) list
+  | Module of (Name.ident * comp) list
+  | Projection of comp * Name.ident
 
 and handler = {
   handler_val: (Name.ident * comp) option;

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -41,8 +41,8 @@ and comp' =
   | Refl of comp
   | Bracket of comp
   | Inhab
-  | Signature of (Name.ident * comp) list
-  | Module of (Name.ident * comp) list
+  | Signature of (Name.ident * Name.ident * comp) list
+  | Module of (Name.ident * Name.ident * comp option * comp) list
   | Projection of comp * Name.ident
 
 and handler = {

--- a/src/utils/error.ml
+++ b/src/utils/error.ml
@@ -32,3 +32,4 @@ let impossible ?loc:(loc=Location.unknown) fmt =
        ####################################################################@\n"
   in
   error ~loc "Impossible error" (message_header ^^ fmt)
+

--- a/src/utils/error.mli
+++ b/src/utils/error.mli
@@ -36,3 +36,4 @@ val fatal : ?loc:Location.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
     in theory that a certain situation cannot exist and we want to alert the
     user to alert us about its existence. *)
 val impossible : ?loc:Location.t -> ('a, Format.formatter, unit, 'b) format4 -> 'a
+


### PR DESCRIPTION
What exactly should happen when evaluating

    { x := e, eq : x == e := refl x}
?
If we do it wrong, we can get something like

    { x : T := e, eq : e == e := refl e } : {x:T, eq : e==e}
which doesn't have the expected type.
Essentially x isn't bound the same way in the type

    x==e
and in the value

    refl x
This double binding gets very annoying, see for instance the fold at line 270 of eval.ml where we carry around 2 environments and it's not clear if we should have 2 contexts as well or something.

We also unfold eagerly in values, so for instance

    { x := big, y := f x x, z := g y y }
will produce

    { x := big, y := f big big, z := g (f big big) (f big big) }
which is kind of horrible.