### PR TITLE
Context.join cleanups

### DIFF
--- a/src/andromeda.ml
+++ b/src/andromeda.ml
@@ -120,7 +120,7 @@ let rec exec_cmd base_dir interactive env c =
           let ((ctxu, u) as ju) = Eval.comp_ty env c in
           let z, env = Environment.add_fresh ~loc:Location.unknown env y ju in
           let w = Tt.abstract_ty zs 0 u in
-          let ctx, eqs = Context.join ctx ctxu in
+          let ctx = Context.join ctx ctxu in
           fold env ctx (z :: zs) ((y, (r, w)) :: yrws) ryus in
      let ctx, yrusv = fold env Context.empty [] [] ryus in
      (* XXX do sth with ctx *)

--- a/src/nucleus/context.ml
+++ b/src/nucleus/context.ml
@@ -172,7 +172,7 @@ let join' ctx1 ctx2 =
         joinA ctx f l
     in joinA ctx1 empty (topological_sort ctx2)
 
-let join ctx1 ctx2 = let ctx,_ = join' ctx1 ctx2 in ctx,[]
+let join ctx1 ctx2 = let ctx,_ = join' ctx1 ctx2 in ctx
 
 
 (** Substitute a variable by a judgment in a context. *)

--- a/src/nucleus/context.mli
+++ b/src/nucleus/context.mli
@@ -26,7 +26,7 @@ val abstract : loc:Location.t -> t -> Name.atom list -> t
 (** Join two contexts into a single one. Return the new context
     and a list of equations that need to be satisfied in order
     for the contexts to be joinable. *)
-val join : t -> t -> t * (Name.atom * Tt.ty * Tt.ty) list
+val join : t -> t -> t
 
 (** [substitute ctx x (ctxe,e,ty_e)] replaces [x] in [ctx] by [e].
     It assumes that the type of [x] in [ctx] is equal to the type of [e] under [ctxe]. *)

--- a/src/nucleus/equal.ml
+++ b/src/nucleus/equal.ml
@@ -41,8 +41,7 @@ and weak_whnf env ctx ((e', loc) as e) =
       | Tt.Prod ([], Tt.Ty e) -> weak ctx e
       | Tt.Spine (e, (xts, t), (_::_ as es)) ->
         begin
-          let (ctx', ((e',eloc) as e)) = weak ctx e in
-          let ctx, eqs = Context.join ctx' ctx in
+          let (ctx, ((e',eloc) as e)) = weak ctx e in
           match e' with
           | Tt.Lambda (xus, (e', u)) ->
             begin
@@ -74,8 +73,7 @@ and weak_whnf env ctx ((e', loc) as e) =
 
       | Tt.Projection (e,xts,p) ->
         begin
-          let (ctx', ((e',eloc) as e)) = weak ctx e in
-          let ctx,_ = Context.join ctx' ctx in
+          let (ctx, ((e',eloc) as e)) = weak ctx e in
           match e' with
             | Tt.Structure xtes ->
               begin
@@ -130,7 +128,7 @@ and whnf env ctx e =
         (Pattern.print_beta_hint [] h) (Tt.print_term [] e) ;
       (* XXX Here a failed join need not be fatal, we could catch and continue
          with the remaining hints *)
-      let ctx, eqs = Context.join ctxh ctx in
+      let ctx = Context.join ctxh ctx in
       (* Here we use beta hints. First we match [p] against [e]. *)
       begin try
           (* XXX collect_* will return contexts *)
@@ -268,7 +266,7 @@ and equal env ctx ((_,loc1) as e1) ((_,loc2) as e2) t =
                 Print.debug "(%d collecting for eta %t" debug_i (Pattern.print_eta_hint [] h);
                 (* XXX Here a failed join need not be fatal, we could catch and continue
                    with the remaining hints *)
-                let ctx, eqs = Context.join ctxh ctx in
+                let ctx = Context.join ctxh ctx in
                 begin match collect_for_eta env ctx (pt, k1, k2) (t, e1, e2) with
                   | None -> 
                      Print.debug "collecting for eta failed early %d)" debug_i;
@@ -355,7 +353,7 @@ and equal_hints env ctx e1 e2 t =
           | ((ctxh, (xts, (pt, pe1, pe2))) as h) :: hs ->
              (* XXX Here a failed join need not be fatal, we could catch and continue
                 with the remaining hints *)
-             let ctx, eqs = Context.join ctx ctxh in
+             let ctx = Context.join ctx ctxh in
              Print.debug "trying general hint@ %t" (Pattern.print_hint [] h);
              begin match collect_for_hint env ctx (pt, pe1, pe2) (t, e1, e2) with
              | None -> fold hs
@@ -1130,7 +1128,7 @@ and inhabit_bracket ~subgoals ~loc env (ctx, t) =
                      (Tt.print_ty [] t) (Pattern.print_inhabit_hint [] h) ;
          (* XXX Here a failed join need not be fatal, we could catch and continue
             with the remaining hints *)
-         let ctx, eqs = Context.join ctx ctxh in
+         let ctx = Context.join ctx ctxh in
          begin match collect_for_inhabit env ctx pt t with
          | None -> fold hs
          | Some (pvars, checks) ->


### PR DESCRIPTION
Remove unnecessary Context.join (close #65) and stop Context.join returning an empty list (close #66).
